### PR TITLE
Dockerize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.tox
+hondana.egg-info
+
+# used by the docker images
+config
+store
+wheelhouse

--- a/README.docker
+++ b/README.docker
@@ -4,10 +4,21 @@ To run hondana in docker, we have prepared a set of 3 docker images:
 2. the build image to build the wheels (build.docker Dockerfile)
 3. the actual hondana image where hondana is deployed w/ nginx
 
-The basic workflow:
+The basic workflow to build the docker images:
 
-	```
+	``` bash
 	# Build the base image
 	docker build -t deployment-base -f base.docker .;
 	# Build the build image
-	docker build -t deployment-builer -f build.docker .;
+	docker build -t deployment-build -f build.docker .;
+	# Build the wheels using the build image. Built wheels are located into $PWD/wheelhouse
+	docker run --rm -v "$(pwd)":/application -v "$(pwd)"/wheelhouse:/wheelhouse deployment-build;
+        # Build the deployment image
+        docker build -t deployment-run -f run.docker
+	```
+
+Then to run hondana:
+
+	``` bash
+	docker run -p 80:80 -v $(pwd)/store:/srv/store deployment-run
+	```

--- a/README.docker
+++ b/README.docker
@@ -4,21 +4,20 @@ To run hondana in docker, we have prepared a set of 3 docker images:
 2. the build image to build the wheels (build.docker Dockerfile)
 3. the actual hondana image where hondana is deployed w/ nginx
 
-The basic workflow to build the docker images:
+The basic workflow to build the docker images is in scripts/build_docker_images.sh:
 
 	``` bash
-	# Build the base image
-	docker build -t deployment-base -f base.docker .;
-	# Build the build image
-	docker build -t deployment-build -f build.docker .;
-	# Build the wheels using the build image. Built wheels are located into $PWD/wheelhouse
-	docker run --rm -v "$(pwd)":/application -v "$(pwd)"/wheelhouse:/wheelhouse deployment-build;
-        # Build the deployment image
-        docker build -t deployment-run -f run.docker
+	bash scripts/build_docker_images.sh
+	```
+
+You then need to create an hondana configuration:
+
+	``` bash
+	mkdir -p config && python scripts/generate_conf.py config.yaml.j2 config/config.yaml
 	```
 
 Then to run hondana:
 
 	``` bash
-	docker run -p 80:80 -v $(pwd)/store:/srv/store deployment-run
+	docker run -p 80:80 -v $(pwd)/store:/srv/store -v $(pwd)/config:/srv/config deployment-run
 	```

--- a/README.docker
+++ b/README.docker
@@ -1,0 +1,13 @@
+To run hondana in docker, we have prepared a set of 3 docker images:
+
+1. the base image (base.docker Dockerfile), to be used for the 2 other images
+2. the build image to build the wheels (build.docker Dockerfile)
+3. the actual hondana image where hondana is deployed w/ nginx
+
+The basic workflow:
+
+	```
+	# Build the base image
+	docker build -t deployment-base -f base.docker .;
+	# Build the build image
+	docker build -t deployment-builer -f build.docker .;

--- a/base.docker
+++ b/base.docker
@@ -1,12 +1,12 @@
 # Set the base image to Ubuntu
-FROM ubuntu
+FROM ubuntu:15.10
 
 MAINTAINER David Cournapeau
 
 RUN apt-get update && \
 	apt-get install -qy \
 		-o APT::Install-Recommends=false -o APT::Install-Suggests=false \
-		python-virtualenv && \
+		virtualenv && \
 	apt-get clean && \
-	virtualenv /srv/env && \
-	/srv/env/bin/pip install -U pip setuptools
+	virtualenv /srv/env -p python3 && \
+	/srv/env/bin/python -m pip install -U pip setuptools

--- a/base.docker
+++ b/base.docker
@@ -1,0 +1,12 @@
+# Set the base image to Ubuntu
+FROM ubuntu
+
+MAINTAINER David Cournapeau
+
+RUN apt-get update && \
+	apt-get install -qy \
+		-o APT::Install-Recommends=false -o APT::Install-Suggests=false \
+		python-virtualenv && \
+	apt-get clean && \
+	virtualenv /srv/env && \
+	/srv/env/bin/pip install -U pip setuptools

--- a/build.docker
+++ b/build.docker
@@ -1,0 +1,16 @@
+FROM deployment-base
+
+RUN . /srv/env/bin/activate; \
+	pip install wheel
+
+ENV WHEELHOUSE=/wheelhouse
+ENV PIP_WHEEL_DIR=/wheelhouse
+ENV PIP_FIND_LINKS=/wheelhouse
+
+VOLUME /wheelhouse
+VOLUME /application
+
+ENTRYPOINT . /srv/env/bin/activate; \
+	cd /application; \
+	pip wheel . \
+	pip wheel gunicorn

--- a/build.docker
+++ b/build.docker
@@ -1,7 +1,6 @@
 FROM deployment-base
 
-RUN . /srv/env/bin/activate; \
-	pip install wheel
+RUN /srv/env/bin/python -m pip install wheel
 
 ENV WHEELHOUSE=/wheelhouse
 ENV PIP_WHEEL_DIR=/wheelhouse
@@ -10,7 +9,7 @@ ENV PIP_FIND_LINKS=/wheelhouse
 VOLUME /wheelhouse
 VOLUME /application
 
-ENTRYPOINT . /srv/env/bin/activate; \
-	cd /application; \
-	pip wheel . \
-	pip wheel gunicorn
+ENTRYPOINT cd /application; \
+	/srv/env/bin/python -V; \
+	/srv/env/bin/python -m pip wheel .; \
+	/srv/env/bin/python -m pip wheel gunicorn

--- a/config.yaml.j2
+++ b/config.yaml.j2
@@ -1,0 +1,2 @@
+store_prefix: "/srv/store"
+secret: "{{ secret }}"

--- a/hondana/__init__.py
+++ b/hondana/__init__.py
@@ -1,3 +1,4 @@
+import os
 import os.path
 
 import flask
@@ -13,7 +14,11 @@ _STORE_PREFIX = "HONDANA_STORE_PREFIX"
 def app_factory():
     store_prefix = os.path.abspath(".store")
 
-    config = Configuration(store_prefix, "a super secret")
+    config_path = os.environ.get("HONDANA_CONFIG")
+    if config_path is None:
+        config_path = "config.yaml"
+
+    config = Configuration.from_path(config_path)
     config.validate()
 
     app = flask.Flask(__name__)

--- a/hondana/__init__.py
+++ b/hondana/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import os.path
 
@@ -44,6 +45,13 @@ def before_request():
     flask.g.projects_metadata = ProjectsMetadataManager.from_directory(
         app.config[_PROJECTS_PREFIX]
     )
+
+@app.before_first_request
+def setup_logging():
+    if not app.debug:
+        # In production mode, add log handler to sys.stderr.
+        app.logger.addHandler(logging.StreamHandler())
+        app.logger.setLevel(logging.INFO)
 
 
 from . import views

--- a/hondana/config.py
+++ b/hondana/config.py
@@ -1,6 +1,7 @@
 import os.path
 
 import six
+import yaml
 
 from attr import attributes, attr
 from attr.validators import instance_of
@@ -12,6 +13,15 @@ from .utils import makedirs
 class Configuration(object):
     store_prefix = attr(validator=instance_of(six.string_types))
     secret_key = attr(validator=instance_of(six.string_types))
+
+    @classmethod
+    def from_path(cls, path):
+        with open(path, "rt") as fp:
+            data = yaml.safe_load(fp)
+
+        store_prefix = data["store_prefix"]
+        secret = data["secret"]
+        return cls(store_prefix, secret)
 
     @property
     def projects_prefix(self):

--- a/nginx.conf.in
+++ b/nginx.conf.in
@@ -1,18 +1,17 @@
 server {
-    listen 8080;
+    listen 80;
     server_name localhost;
   
     location /static/ {
-    	alias /home/vagrant/src/hondana/static/;
+        alias HONDANA_SOURCES/static/;
     }
  
-    location /doc-static/ {
-        #internal; 
-    	alias /home/vagrant/src/hondana/.store/;
+    location /docs-static/ {
+        alias HONDANA_SOURCES/.store/;
     }
  
     location / {
-  	proxy_set_header X-Sendfile-Type X-Accel-Redirect;
+        proxy_set_header X-Sendfile-Type X-Accel-Redirect;
  
         proxy_set_header X-Forward-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;

--- a/nginx.conf.in
+++ b/nginx.conf.in
@@ -7,7 +7,7 @@ server {
     }
  
     location /docs-static/ {
-        alias HONDANA_SOURCES/.store/;
+        alias HONDANA_STORE/;
     }
  
     location / {

--- a/run.docker
+++ b/run.docker
@@ -1,0 +1,26 @@
+# run.docker
+FROM deployment-base
+
+ADD . /srv/hondana-git
+
+COPY nginx.conf.in /etc/nginx/sites-enabled/hondana
+
+RUN apt-get install -qy \
+		-o APT::Install-Recommends=false -o APT::Install-Suggests=false \
+		nginx supervisor && \
+	apt-get clean && \
+	unlink /etc/nginx/sites-enabled/default && \
+	sed -e "s|HONDANA_SOURCES|/srv/hondana-git|g" -i /etc/nginx/sites-enabled/hondana && \
+	/srv/env/bin/pip install --no-index -f /srv/hondana-git/wheelhouse hondana gunicorn && \
+	/srv/env/bin/python \
+		/srv/hondana-git/scripts/generate_conf.py \
+		/srv/hondana-git/config.yaml.j2 /srv/hondana-git/config.yaml
+
+VOLUME /srv/store
+
+COPY supervisor.conf /etc/supervisor/conf.d/hondana.conf
+
+# Run the app
+EXPOSE 80
+ENV HONDANA_CONFIG /srv/hondana-git/config.yaml
+CMD ["/usr/bin/supervisord", "-n"]

--- a/run.docker
+++ b/run.docker
@@ -12,16 +12,14 @@ RUN apt-get install -qy \
 	unlink /etc/nginx/sites-enabled/default && \
 	sed -e "s|HONDANA_SOURCES|/srv/hondana-git|g" -i /etc/nginx/sites-enabled/hondana && \
 	sed -e "s|HONDANA_STORE|/srv/store|g" -i /etc/nginx/sites-enabled/hondana && \
-	/srv/env/bin/pip install --no-index -f /srv/hondana-git/wheelhouse hondana gunicorn && \
-	/srv/env/bin/python \
-		/srv/hondana-git/scripts/generate_conf.py \
-		/srv/hondana-git/config.yaml.j2 /srv/hondana-git/config.yaml
+	/srv/env/bin/pip install --no-index -f /srv/hondana-git/wheelhouse hondana gunicorn
 
 VOLUME /srv/store
+VOLUME /srv/config
 
 COPY supervisor.conf /etc/supervisor/conf.d/hondana.conf
 
 # Run the app
 EXPOSE 80
-ENV HONDANA_CONFIG /srv/hondana-git/config.yaml
+ENV HONDANA_CONFIG /srv/config/config.yaml
 CMD ["/usr/bin/supervisord", "-n"]

--- a/run.docker
+++ b/run.docker
@@ -11,6 +11,7 @@ RUN apt-get install -qy \
 	apt-get clean && \
 	unlink /etc/nginx/sites-enabled/default && \
 	sed -e "s|HONDANA_SOURCES|/srv/hondana-git|g" -i /etc/nginx/sites-enabled/hondana && \
+	sed -e "s|HONDANA_STORE|/srv/store|g" -i /etc/nginx/sites-enabled/hondana && \
 	/srv/env/bin/pip install --no-index -f /srv/hondana-git/wheelhouse hondana gunicorn && \
 	/srv/env/bin/python \
 		/srv/hondana-git/scripts/generate_conf.py \

--- a/scripts/build_docker_images.sh
+++ b/scripts/build_docker_images.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+# Build the base image
+docker build -t deployment-base -f base.docker .;
+# Build the build image
+docker build -t deployment-build -f build.docker .;
+# Build the wheels using the build image. Built wheels are located into $PWD/wheelhouse
+docker run --rm -v "$(pwd)":/application -v "$(pwd)"/wheelhouse:/wheelhouse deployment-build;
+# Build the deployment image
+docker build -t deployment-run -f run.docker .;

--- a/scripts/generate_conf.py
+++ b/scripts/generate_conf.py
@@ -1,0 +1,25 @@
+import base64
+import os
+import sys
+
+import jinja2
+
+
+def main(argv=None):
+    argv = argv or sys.argv[1:]
+
+    template_path = argv[0]
+    output = argv[1]
+
+    with open(template_path) as fp:
+        data = fp.read()
+
+    template = jinja2.Template(data)
+    secret = base64.b64encode(os.urandom(24))
+
+    with open(output, "wt") as fp:
+        fp.write(template.render(secret=secret))
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="hondana",
     version="0.0.1.dev0",
-    install_requires=["attrs", "flask", "six"],
+    install_requires=["attrs", "flask", "pyyaml", "six"],
     packages=["hondana"],
     package_data={"hondana.templates": "*.html", "hondana.static": "*.css"}
 )

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     name="hondana",
     version="0.0.1.dev0",
     install_requires=["attrs", "flask", "pyyaml", "six"],
-    packages=["hondana"],
-    package_data={"hondana.templates": "*.html", "hondana.static": "*.css"}
+    packages=["hondana", "hondana.templates"],
+    package_data={"hondana.templates": ["*.html"]},
+    include_package_data=True,
 )

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,0 +1,5 @@
+[program:nginx]
+command=nginx -g "daemon off;"
+
+[program:gunicorn]
+command=/srv/env/bin/gunicorn --bin localhost:5000 hondana:app


### PR DESCRIPTION
Basic docker workflow for hondana:
1. a base image used by the other ones
2. a build image to build wheels
3. a deployment image based on 1. that install wheels from 2.

@sjagoe for the deployment container, it seems that running `CMD ["supervisord"]` without the `--no-daemon` does not start supervisor. As is, it runs as expected w/ the `-n` option, but then the container run is attached to the tty
